### PR TITLE
Fixed output for Python 3.7

### DIFF
--- a/postgres_mitm.py
+++ b/postgres_mitm.py
@@ -314,10 +314,10 @@ class ClientConnection(threading.Thread):
         password = parse_password_from_authentication_packet(data)
         if self.connect_to_actual_backend(password):
             captured_uri = 'postgres://%(user)s:%(password)s@%(host)s:5432/%(database)s' % {
-                'user': self.options.get('user', b''),
-                'password': password,
+                'user': self.options.get('user', b'').decode('utf-8'),
+                'password': password.decode('utf-8'),
                 'host': self.target_backend,
-                'database': self.options.get('database', b''),
+                'database': self.options.get('database', b'').decode('utf-8'),
             }
             _logger.info('Intercepted auth: %s' % captured_uri)
             # Switch socket to non-blocking to enable messages to pass in


### PR DESCRIPTION
Hey @thusoy, this is a really great project and brings attention to a pretty big issue 💯 

In Python 3.7, the output is:

```
Intercepted auth: postgres://bytearray(b'user'):bytearray(b'password')@1.1.1.1:5432/bytearray(b'dbname')
```

This fixes it, while also working with Python 2.