### PR TITLE
Add TLS1.3 to postgres_get_server_cert.py

### DIFF
--- a/postgres_get_server_cert.py
+++ b/postgres_get_server_cert.py
@@ -66,7 +66,7 @@ def request_ssl(sock):
 
 def get_ssl_context():
     # Return the strongest SSL context available locally
-    for proto in ('PROTOCOL_TLSv1_2', 'PROTOCOL_TLSv1', 'PROTOCOL_SSLv23'):
+    for proto in ('PROTOCOL_TLSv1_3', 'PROTOCOL_TLSv1_2', 'PROTOCOL_TLSv1', 'PROTOCOL_SSLv23'):
         protocol = getattr(ssl, proto, None)
         if protocol:
             break


### PR DESCRIPTION
This PR is related to #9 :
The script for getting the server certificate should be aware of the existence of TLS version 1.3.

However, the proposed patch does not seem to get rid of the warning mentioned in #9 (even though it does solve some connection errors I was getting when using a certificate generated without the patch).